### PR TITLE
Add registration validation and more activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Join the school soccer team and compete in matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["alex@mergington.edu", "mia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Practice and play basketball with the school team",
+        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["ethan@mergington.edu", "ava@mergington.edu"]
+    },
+    "Art Club": {
+        "description": "Explore your creativity through painting and drawing",
+        "schedule": "Mondays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["lily@mergington.edu", "noah@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Participate in plays and improve your acting skills",
+        "schedule": "Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["amelia@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Math Club": {
+        "description": "Solve challenging math problems and prepare for competitions",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 10,
+        "participants": ["harper@mergington.edu", "jack@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Conduct experiments and explore scientific concepts",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 12,
+        "participants": ["ella@mergington.edu", "logan@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specificy activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        return {"message": f"{email} is already signed up for {activity_name}"}
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -25,6 +25,10 @@ document.addEventListener("DOMContentLoaded", () => {
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <p><strong>Participants:</strong></p>
+          <ul>
+            ${details.participants.map(participant => `<li>${participant}</li>`).join("")}
+          </ul>
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -87,4 +87,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Initialize app
   fetchActivities();
+
+  document.getElementById("theme-toggle").addEventListener("click", () => {
+    document.body.classList.toggle("dark-theme");
+  });
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,7 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <button id="theme-toggle">Toggle Theme</button>
     </header>
 
     <main>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,18 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.activity-card ul {
+  margin-top: 10px;
+  padding-left: 20px;
+  list-style-type: disc;
+  color: #555;
+}
+
+.activity-card ul li {
+  margin-bottom: 5px;
+  font-size: 14px;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -15,6 +15,11 @@ body {
   background-color: #f5f5f5;
 }
 
+body.dark-theme {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
 header {
   text-align: center;
   padding: 20px 0;
@@ -22,6 +27,10 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+body.dark-theme header {
+  background-color: #333;
 }
 
 header h1 {
@@ -50,6 +59,11 @@ section {
   max-width: 500px;
 }
 
+body.dark-theme section {
+  background-color: #1e1e1e;
+  color: #e0e0e0;
+}
+
 section h3 {
   margin-bottom: 20px;
   padding-bottom: 10px;
@@ -63,6 +77,11 @@ section h3 {
   border: 1px solid #ddd;
   border-radius: 5px;
   background-color: #f9f9f9;
+}
+
+body.dark-theme .activity-card {
+  background-color: #2c2c2c;
+  border-color: #444;
 }
 
 .activity-card h4 {
@@ -116,8 +135,16 @@ button {
   transition: background-color 0.2s;
 }
 
+body.dark-theme button {
+  background-color: #444;
+}
+
 button:hover {
   background-color: #3949ab;
+}
+
+body.dark-theme button:hover {
+  background-color: #555;
 }
 
 .message {
@@ -132,10 +159,20 @@ button:hover {
   border: 1px solid #a5d6a7;
 }
 
+body.dark-theme .success {
+  background-color: #2e7d32;
+  color: #e8f5e9;
+}
+
 .error {
   background-color: #ffebee;
   color: #c62828;
   border: 1px solid #ef9a9a;
+}
+
+body.dark-theme .error {
+  background-color: #c62828;
+  color: #ffebee;
 }
 
 .info {
@@ -153,4 +190,8 @@ footer {
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+body.dark-theme footer {
+  color: #888;
 }

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -195,3 +195,33 @@ footer {
 body.dark-theme footer {
   color: #888;
 }
+
+.participant-info {
+  background-color: #e3f2fd;
+  padding: 20px;
+  border-radius: 5px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  margin-bottom: 20px;
+  color: #0d47a1;
+}
+
+body.dark-theme .participant-info {
+  background-color: #1a237e;
+  color: #bbdefb;
+}
+
+.participant-info h4 {
+  margin-bottom: 10px;
+  font-size: 18px;
+  color: #0d47a1;
+}
+
+body.dark-theme .participant-info h4 {
+  color: #bbdefb;
+}
+
+.participant-info p {
+  margin-bottom: 8px;
+  font-size: 16px;
+  line-height: 1.5;
+}


### PR DESCRIPTION
This pull request includes several enhancements and new features for the extracurricular activities application. The most significant changes are the addition of new activities, improved participant management, and the introduction of a dark theme for the user interface.

### New Activities and Participant Management:

* [`src/app.py`](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R41-R76): Added new activities including Soccer Team, Basketball Team, Art Club, Drama Club, Math Club, and Science Club.
* [`src/app.py`](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R101-R104): Updated the `signup_for_activity` function to validate that a student is not already signed up for an activity before adding them.

### User Interface Enhancements:

* [`src/static/app.js`](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R28-R31): Updated the activity cards to display the list of participants for each activity.
* [`src/static/app.js`](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R90-R93): Added a toggle button to switch between light and dark themes.
* [`src/static/index.html`](diffhunk://#diff-6c71709b4d31c8f650dbe64ffc24d55cede1d64448e827c4b1292ffeb2a3acc3R13): Added a button in the header to toggle the theme.

### Dark Theme Styling:

* [`src/static/styles.css`](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R18-R22): Added CSS rules for dark theme, including background and text color adjustments for the body, header, sections, activity cards, buttons, and participant info. [[1]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R18-R22) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R32-R35) [[3]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R62-R66) [[4]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R82-R86) [[5]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R96-R107) [[6]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R138-R149) [[7]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R162-R177) [[8]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R194-R227)